### PR TITLE
Centralized gradle dependencies in some kts files

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
@@ -10,6 +11,7 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
+            <option value="$PROJECT_DIR$/buildSrc" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,20 +5,18 @@ plugins {
     id("com.google.dagger.hilt.android")
 }
 
-val compose_ui_version = "1.2.0"
-
 android {
     namespace = "me.ismartin.musicstoptimer"
-    compileSdk = 33
+    compileSdk = AppConfig.compileSdk
 
     defaultConfig {
         applicationId = "me.ismartin.musicstoptimer"
-        minSdk = 24
-        targetSdk = 33
-        versionCode = 1
-        versionName = "1.0"
+        minSdk = AppConfig.minSdk
+        targetSdk = AppConfig.targetSdk
+        versionCode = AppConfig.versionCode
+        versionName = AppConfig.versionName
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = Dependencies.JUnit.instrumentationRunner
         vectorDrawables {
             useSupportLibrary = true
         }
@@ -38,14 +36,14 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = AppConfig.jvmTarget
     }
     buildFeatures.compose = true
     buildFeatures {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.0"
+        kotlinCompilerExtensionVersion = AppConfig.kotlinCompilerExtension
     }
     packagingOptions {
         resources {
@@ -55,29 +53,11 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.10.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
-    implementation("androidx.activity:activity-compose:1.7.0")
-    implementation("androidx.compose.ui:ui:$compose_ui_version")
-    implementation("androidx.compose.ui:ui-tooling-preview:$compose_ui_version")
-    implementation("androidx.compose.material:material:1.4.1")
-
-    implementation("androidx.navigation:navigation-compose:2.6.0-alpha09")
-    implementation("androidx.datastore:datastore-preferences:1.0.0")
-    implementation("androidx.activity:activity-ktx:1.7.0")
-
-    implementation("com.google.dagger:hilt-android:2.44")
-    kapt("com.google.dagger:hilt-android-compiler:2.44")
-
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("androidx.test:core-ktx:1.5.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:$compose_ui_version")
-    androidTestImplementation("androidx.test:runner")
-    debugImplementation("androidx.compose.ui:ui-tooling:$compose_ui_version")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:$compose_ui_version")
+    implementation(Dependencies.appLibraries)
+    kapt(Dependencies.kaptLibraries)
+    testImplementation(Dependencies.testLibraries)
+    androidTestImplementation(Dependencies.androidTestLibraries)
+    debugImplementation(Dependencies.debugLibraries)
 }
 
 kapt {
@@ -96,7 +76,7 @@ fun Project.setupKtlint() {
         }
     }
     dependencies {
-        ktlintConfiguration("com.pinterest:ktlint:0.45.2")
+        ktlintConfiguration(Dependencies.Pinterest.ktlint)
     }
 
     val directoriesWithSource = listOf(

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,9 @@
+import org.gradle.kotlin.dsl.`kotlin-dsl`
+
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -1,0 +1,10 @@
+object AppConfig {
+    const val compileSdk = 32
+    const val minSdk = 24
+    const val targetSdk = 32
+    const val versionCode = 1
+    const val versionName = "1.0.0"
+
+    const val jvmTarget = "1.8"
+    const val kotlinCompilerExtension = "1.4.0"
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,0 +1,112 @@
+import org.gradle.api.artifacts.dsl.DependencyHandler
+
+object Dependencies {
+
+    object Android {
+        val activity = "androidx.activity:activity-ktx:${Versions.activityKtx}"
+        val coreKtx = "androidx.core:core-ktx:${Versions.coreKtx}"
+        val dataStore = "androidx.datastore:datastore-preferences:${Versions.dataStorePreferences}"
+        val lifecycleKtx = "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.lifecycleKtx}"
+        val testCoreKtx = "androidx.test:core-ktx:${Versions.testCoreKtx}"
+        val testRunner = "androidx.test:runner"
+    }
+
+    object Compose {
+        val activity = "androidx.activity:activity-compose:${Versions.composeActivity}"
+        val core = "androidx.compose.ui:ui:${Versions.compose}"
+        val debugManifest = "androidx.compose.ui:ui-test-manifest:${Versions.compose}"
+        val debugTooling = "androidx.compose.ui:ui-tooling:${Versions.compose}"
+        val junit = "androidx.compose.ui:ui-test-junit4:${Versions.compose}"
+        val material = "androidx.compose.material:material:${Versions.composeMaterial}"
+        val navigation = "androidx.navigation:navigation-compose:${Versions.composeNavigation}"
+        val tooling = "androidx.compose.ui:ui-tooling-preview:${Versions.compose}"
+    }
+
+    object Coroutines {
+        val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutinesTest}"
+    }
+
+    object Espresso {
+        val core = "androidx.test.espresso:espresso-core:${Versions.espresso}"
+    }
+
+    object Hilt {
+        val core = "com.google.dagger:hilt-android:${Versions.hilt}"
+        val compiler = "com.google.dagger:hilt-android-compiler:${Versions.hilt}"
+    }
+
+    object JUnit {
+        val core = "junit:junit:${Versions.junit}"
+        val ext = "androidx.test.ext:junit:${Versions.junitExt}"
+        val instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    object Pinterest {
+        val ktlint = "com.pinterest:ktlint:${Versions.ktlint}"
+    }
+
+    val appLibraries = arrayListOf<String>(
+        Android.activity,
+        Android.coreKtx,
+        Android.dataStore,
+        Android.lifecycleKtx,
+        Compose.activity,
+        Compose.core,
+        Compose.tooling,
+        Compose.material,
+        Compose.navigation,
+        Hilt.core,
+    )
+
+    val kaptLibraries = arrayListOf<String>(
+        Hilt.compiler,
+    )
+
+    val testLibraries = arrayListOf<String>(
+        Android.testCoreKtx,
+        Coroutines.test,
+        JUnit.core,
+    )
+
+    val androidTestLibraries = arrayListOf<String>(
+        Android.testRunner,
+        Compose.junit,
+        Espresso.core,
+        JUnit.ext,
+    )
+
+    val debugLibraries = arrayListOf<String>(
+        Compose.debugManifest,
+        Compose.debugTooling,
+    )
+}
+
+fun DependencyHandler.implementation(list: List<String>) {
+    list.forEach { dependency ->
+        add("implementation", dependency)
+    }
+}
+
+fun DependencyHandler.kapt(list: List<String>) {
+    list.forEach { dependency ->
+        add("kapt", dependency)
+    }
+}
+
+fun DependencyHandler.testImplementation(list: List<String>) {
+    list.forEach { dependency ->
+        add("testImplementation", dependency)
+    }
+}
+
+fun DependencyHandler.androidTestImplementation(list: List<String>) {
+    list.forEach { dependency ->
+        add("androidTestImplementation", dependency)
+    }
+}
+
+fun DependencyHandler.debugImplementation(list: List<String>) {
+    list.forEach { dependency ->
+        add("debugImplementation", dependency)
+    }
+}

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,0 +1,17 @@
+object Versions {
+    val activityKtx = "1.5.1"
+    val compose = "1.1.0"
+    val composeActivity = "1.5.0"
+    val composeMaterial = "1.2.1"
+    val composeNavigation = "2.5.3"
+    val coreKtx = "1.8.0"
+    val coroutinesTest = "1.6.4"
+    val dataStorePreferences = "1.0.0"
+    val espresso = "3.5.1"
+    val hilt = "2.44"
+    val junit = "4.13.2"
+    val junitExt = "1.1.5"
+    val ktlint = "0.45.2"
+    val lifecycleKtx = "2.4.0"
+    val testCoreKtx = "1.5.0"
+}


### PR DESCRIPTION
**Centralized gradle dependencies in some kts files**

The idea is having a file with all dependencies used on this app, I was thinking to centralize them in separate files, also versions and app config values were located in a specific file. _Gradle kts_ files were modified to call dependencies and app config values.

I based this commit on this source: `https://medium.com/android-dev-hacks/kotlin-dsl-gradle-scripts-in-android-made-easy-b8e2991e2ba`