### PR TITLE
Modified settings screen

### DIFF
--- a/app/src/main/java/me/ismartin/musicstoptimer/MainActivity.kt
+++ b/app/src/main/java/me/ismartin/musicstoptimer/MainActivity.kt
@@ -31,7 +31,11 @@ class MainActivity : ComponentActivity() {
                         HomeScreen(navController)
                     }
                     composable(Destinations.Settings.route) {
-                        SettingsScreen(navController, viewModel)
+                        SettingsScreen(
+                            navController = navController,
+                            settingsState = viewModel.settingsState.collectAsState().value,
+                            settingsEvent = viewModel::processSettingsEvents
+                        )
                     }
                 }
             }

--- a/app/src/main/java/me/ismartin/musicstoptimer/repositories/models/SettingDisplayModel.kt
+++ b/app/src/main/java/me/ismartin/musicstoptimer/repositories/models/SettingDisplayModel.kt
@@ -29,3 +29,14 @@ enum class SettingName(
     MEDIA_PLAYER_1("mediaPlayer1", R.string.set_media_player_1),
     MEDIA_PLAYER_2("mediaPlayer2", R.string.set_media_player_2),
 }
+
+sealed class SettingsEvent {
+    data class OnSwitchSettingChange(
+        val setting: SettingDisplayModel,
+        val newValue: Boolean
+    ) : SettingsEvent()
+    data class OnSingleSelectionSettingChange(
+        val setting: SettingDisplayModel,
+        val newValue: String
+    ) : SettingsEvent()
+}

--- a/app/src/main/java/me/ismartin/musicstoptimer/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/me/ismartin/musicstoptimer/ui/screens/SettingsScreen.kt
@@ -2,13 +2,17 @@ package me.ismartin.musicstoptimer.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
@@ -16,7 +20,6 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -24,46 +27,65 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import me.ismartin.musicstoptimer.BuildConfig
+import me.ismartin.musicstoptimer.R
 import me.ismartin.musicstoptimer.repositories.models.SettingDisplayModel
 import me.ismartin.musicstoptimer.repositories.models.SettingType
-import me.ismartin.musicstoptimer.viewmodels.MainViewModel
+import me.ismartin.musicstoptimer.repositories.models.SettingsEvent
+import me.ismartin.musicstoptimer.ui.theme.MusicStopTimerTheme
 
 @Composable
-fun SettingsScreen(navController: NavController, viewModel: MainViewModel) {
-    val settingsList = viewModel.settingsState.collectAsState()
-
+fun SettingsScreen(
+    navController: NavController,
+    settingsState: List<SettingDisplayModel>,
+    settingsEvent: (SettingsEvent) -> Unit,
+) {
     Scaffold(
-        topBar = { TopBar(navController = navController) }
+        topBar = {
+            TopBar(onNavigationClick = { navController.navigateUp() })
+        }
     ) { paddingValues ->
-        LazyColumn(contentPadding = paddingValues) {
-            items(settingsList.value) { setting ->
-                when (setting.type) {
-                    is SettingType.SingleSelection -> {
-                        Text(text = stringResource(id = setting.displayName))
-                    }
-                    is SettingType.Switch -> SwitchSetting(setting = setting) { newValue ->
-                        viewModel.updateSwitchSettingValue(setting, newValue)
+        Column {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .weight(1f),
+                contentPadding = paddingValues
+            ) {
+                items(settingsState) { setting ->
+                    when (setting.type) {
+                        is SettingType.SingleSelection -> {
+                            // todo: SingleSelectionSetting -> change to appSelectionSetting?
+                        }
+
+                        is SettingType.Switch -> SwitchSetting(setting = setting) { newValue ->
+                            settingsEvent(SettingsEvent.OnSwitchSettingChange(setting, newValue))
+                        }
                     }
                 }
             }
+            VersionSetting(modifier = Modifier.fillMaxWidth())
         }
     }
 }
 
 @Composable
-fun TopBar(navController: NavController) {
+fun TopBar(onNavigationClick: () -> Unit) {
     TopAppBar(
         modifier = Modifier,
         title = {
-            Text(text = "Settings")
+            Text(text = stringResource(id = R.string.settings))
         },
         navigationIcon = {
-            IconButton(onClick = { navController.navigateUp() }) {
+            IconButton(onClick = onNavigationClick) {
                 Icon(
                     imageVector = Icons.Filled.ArrowBack,
-                    contentDescription = "Back"
+                    contentDescription = stringResource(id = R.string.content_back_navigation)
                 )
             }
         }
@@ -71,7 +93,33 @@ fun TopBar(navController: NavController) {
 }
 
 @Composable
-fun SwitchSetting(setting: SettingDisplayModel, onCheckedChange: (Boolean) -> Unit) {
+fun VersionSetting(
+    modifier: Modifier = Modifier
+) {
+    val appVersion = BuildConfig.VERSION_NAME
+    Box(modifier = modifier) {
+        Column {
+            Divider(
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colors.onSecondary
+            )
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                text = stringResource(id = R.string.app_version, appVersion),
+                color = MaterialTheme.colors.onSecondary,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+fun SwitchSetting(
+    setting: SettingDisplayModel,
+    onCheckedChange: (Boolean) -> Unit
+) {
     var settingValue by remember {
         mutableStateOf((setting.type as SettingType.Switch).value)
     }
@@ -98,5 +146,17 @@ fun SwitchSetting(setting: SettingDisplayModel, onCheckedChange: (Boolean) -> Un
                 }
             )
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SettingsScreenPreview() {
+    MusicStopTimerTheme {
+        SettingsScreen(
+            navController = rememberNavController(),
+            settingsState = listOf(),
+            settingsEvent = {}
+        )
     }
 }

--- a/app/src/main/java/me/ismartin/musicstoptimer/ui/theme/Theme.kt
+++ b/app/src/main/java/me/ismartin/musicstoptimer/ui/theme/Theme.kt
@@ -5,17 +5,30 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 
 private val DarkColorPalette = darkColors(
     primary = Purple200,
     primaryVariant = Purple700,
-    secondary = Teal200
+    secondary = Teal200,
+    background = Color.Black,
+    surface = Color.Black,
+    onPrimary = Color.Black,
+    onSecondary = Color.White,
+    onBackground = Color.White,
+    onSurface = Color.White,
 )
 
 private val LightColorPalette = lightColors(
     primary = Purple500,
     primaryVariant = Purple700,
-    secondary = Teal200
+    secondary = Teal200,
+    background = Color.White,
+    surface = Color.White,
+    onPrimary = Color.White,
+    onSecondary = Color.Black,
+    onBackground = Color.Black,
+    onSurface = Color.Black,
 
     /* Other default colors to override
     background = Color.White,

--- a/app/src/main/java/me/ismartin/musicstoptimer/utils/Extensions.kt
+++ b/app/src/main/java/me/ismartin/musicstoptimer/utils/Extensions.kt
@@ -1,0 +1,1 @@
+package me.ismartin.musicstoptimer.utils

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,14 @@
 <resources>
     <string name="app_name">MusicStopTimer</string>
 
-    <string name="content_description_settings">Settings</string>
+    <string name="content_back_navigation">Back</string>
 
+    <string name="settings">Settings</string>
+    <string name="content_description_settings">Settings</string>
     <string name="set_dark_theme">Set dark theme</string>
     <string name="turn_off_bluetooth">Turn off Bluetooth</string>
     <string name="set_media_player_1">Set media player 1</string>
     <string name="set_media_player_2">Set media player 2</string>
+    <string name="app_version">Version %s</string>
 
 </resources>


### PR DESCRIPTION
Enhancement on settings, viewModel is not a parameter on Settings screen

Settings screen parameters (viewModel was removed, settingsState and settingsEvent were added) were modified to have a settings state and event, this will help to show a composable preview, some composable components were modified to use and call those parameters. Besides version app label was included on settings.

Theming was modified to include more color cases.